### PR TITLE
Switch to HMTL5 player

### DIFF
--- a/multitwitch/static/css/multitwitch.css
+++ b/multitwitch/static/css/multitwitch.css
@@ -23,6 +23,10 @@ a:hover {
     padding: 0;
 }
 
+iframe {
+    border:0 none;
+}
+
 #chatbox {
     float: right;
     width: 320px;

--- a/multitwitch/static/js/multitwitch.js
+++ b/multitwitch/static/js/multitwitch.js
@@ -125,7 +125,7 @@ function stream_item_keyup(e) {
 }
 
 function stream_object(name) {
-    return $('<object type="application/x-shockwave-flash" id="embed_' + name + '" class="stream" data="http://www.twitch.tv/widgets/live_embed_player.swf?channel="' + name + '"><param name="allowFullScreen" value="true" /><param name="allowScriptAccess" value="always" /><param name="allowNetworking" value="all" /><param name="movie" value="http://www.twitch.tv/widgets/live_embed_player.swf" /><param name="wmode" value="opaque" /><param name="flashvars" value="hostname=www.twitch.tv&channel=' + name + '&auto_play=true&start_volume=0" /></object>');
+    return $('<iframe id="embed_' + name + '" src="http://player.twitch.tv/?volume=0.00&channel=' + name + '" class="stream" allowfullscreen></iframe>');
 }
 
 function chat_object(name) {

--- a/multitwitch/templates/web/home.tmpl
+++ b/multitwitch/templates/web/home.tmpl
@@ -51,13 +51,13 @@ $(window).resize(function() {
 <div id="wrapper">
 <div id="streams">
     {% for stream in streams %}
-    
+
     {% if not is_test %}
-    <object type="application/x-shockwave-flash" height="255" width="400" id="embed_{{ stream }}" class="stream" data="http://www.twitch.tv/widgets/live_embed_player.swf?channel={{ stream }}" bgcolor="#000000"><param name="allowFullScreen" value="true" /><param name="allowScriptAccess" value="always" /><param name="allowNetworking" value="all" /><param name="movie" value="http://www.twitch.tv/widgets/live_embed_player.swf" /><param name="flashvars" value="hostname=www.twitch.tv&channel={{ stream }}&auto_play=true&start_volume=0" /><param name="wmode" value="opaque" /></object>
+    <iframe id="embed_{{ stream }}" src="http://player.twitch.tv/?volume=0.00&channel={{ stream }}" class="stream" allowfullscreen></iframe>
     {% else %}
     <object type="application/x-shockwave-flash" height="255" width="400" id="embed_{{ stream }}" class="stream" data="http://beta.twitch.tv/widgets/live_embed_player.swf?channel={{ stream }}" bgcolor="#000000"><param name="allowFullScreen" value="true" /><param name="allowScriptAccess" value="always" /><param name="allowNetworking" value="all" /><param name="movie" value="http://www.twitch.tv/widgets/live_embed_player.swf" /><param name="flashvars" value="hostname=www.twitch.tv&channel={{ stream }}&auto_play=true&start_volume=0" /><param name="wmode" value="transparent" /></object>
     {% endif %}
-    
+
     {% endfor %}
 </div>
 


### PR DESCRIPTION
These are the minimum changes to get multitwitch to support the HTML5 twitch video player. This will remove the requirement for flash and make multitwitch usable on mobile devices.