### PR TITLE
Hide chat on load

### DIFF
--- a/multitwitch/static/js/multitwitch.js
+++ b/multitwitch/static/js/multitwitch.js
@@ -196,3 +196,14 @@ function close_change_streams(apply) {
     $("#change_streams").hide();
     update_stream_list();
 }
+
+$(document).ready(function() {
+  if (!URLSearchParams) {
+    return;
+  }
+    
+  var searchParams = new URLSearchParams(window.location.search);  
+  if (searchParams.get('chat') === '0') {
+      hide_chat();
+  }
+});


### PR DESCRIPTION
Hide the chat when the page is loaded with the search-param `chat=0`. I.e http://www.multitwitch.tv/gunnermaniac3/narcissawright?chat=0