### PR TITLE
Add darkpopout parameter to chat embed

### DIFF
--- a/multitwitch/templates/web/home.tmpl
+++ b/multitwitch/templates/web/home.tmpl
@@ -65,7 +65,7 @@ $(window).resize(function() {
 </ul>
 {% for stream in unique_streams %}
 <div id="chat-{{ stream|e }}" class="stream_chat">
-<iframe frameborder="0" scrolling="no" id="chat-{{ stream|e }}-embed" src="https://twitch.tv/embed/{{ stream|e }}/chat?parent=multitwitch.tv&amp;parent=www.multitwitch.tv" height="100%" width="100%"></iframe>
+<iframe frameborder="0" scrolling="no" id="chat-{{ stream|e }}-embed" src="https://twitch.tv/embed/{{ stream|e }}/chat?parent=multitwitch.tv&amp;parent=www.multitwitch.tv{% if darkmode %}&darkpopout{% endif %}" height="100%" width="100%"></iframe>
 </div>
 {% endfor %}
 </div>

--- a/multitwitch/views/web.py
+++ b/multitwitch/views/web.py
@@ -5,6 +5,7 @@ class WebView:
     @web(template="web/home.tmpl")
     def home(request):
         streams = request.matchdict['streams']
+        darkmode = 'darkmode' in request.params
         uniq_streams = []
         for s in streams:
             if s not in uniq_streams:
@@ -12,7 +13,8 @@ class WebView:
         return {'project' : 'multitwitch',
                 'streams' : streams,
                 'unique_streams' : uniq_streams,
-                'nstreams' : len(streams)}
+                'nstreams' : len(streams),
+                'darkmode' : darkmode}
 
     @staticmethod
     def favicon(request):


### PR DESCRIPTION
Alternative pull request to https://github.com/bhamrick/multitwitch/pull/40 to fix https://github.com/bhamrick/multitwitch/issues/30.

Intead of adding a UI button, just pull parameter from querystring and use on rendering template.

I think dark mode is a very desirable feature, no matter how it is enabled.